### PR TITLE
Put external lightmap atlases on the BSP lightmap contract

### DIFF
--- a/code/renderer/tr_image.c
+++ b/code/renderer/tr_image.c
@@ -883,9 +883,17 @@ image_t *R_CreateImage( const char *name, const char *name2, byte *pic, int widt
 	image->colorSpace = R_ImageColorSpaceForFlags( image->imgName, image->flags );
 
 	if ( namelen > 6 && Q_stristr( image->imgName, "maps/" ) == image->imgName && Q_stristr( image->imgName + 6, "/lm_" ) != NULL ) {
-		// external lightmap atlases stored in maps/<mapname>/lm_XXXX textures
-		//image->flags = IMGFLAG_NOLIGHTSCALE | IMGFLAG_NO_COMPRESSION | IMGFLAG_NOSCALE | IMGFLAG_COLORSHIFT;
-		image->flags |= IMGFLAG_NO_COMPRESSION | IMGFLAG_NOSCALE | IMGFLAG_COLORSPACE_LINEAR;
+		// external lightmap atlases stored in maps/<mapname>/lm_XXXX textures.
+		// These arrive through the regular shader/image path, so they must be
+		// forced onto the same contract R_LoadLightmaps() gives BSP lightmaps:
+		// bake the overbright/greyscale shift (R_ProcessLightmap() does that for
+		// the internal ones), skip the intensity+gamma light scale so it is not
+		// applied on top of the diffuse texture's, and keep the authored size.
+		// picmip and mipmapping are cleared because a packed atlas has no border
+		// padding, so they would blur and bleed neighbouring lightmap tiles.
+		image->flags &= ~( IMGFLAG_MIPMAP | IMGFLAG_PICMIP );
+		image->flags |= IMGFLAG_NOLIGHTSCALE | IMGFLAG_NO_COMPRESSION | IMGFLAG_NOSCALE |
+			IMGFLAG_COLORSHIFT | IMGFLAG_COLORSPACE_LINEAR;
 		image->colorSpace = IMAGE_COLORSPACE_LINEAR;
 	}
 	image->srgbDecode = R_ImageWantsSrgbDecode( image->colorSpace );

--- a/code/rendererrtx/tr_image.c
+++ b/code/rendererrtx/tr_image.c
@@ -1061,9 +1061,17 @@ image_t *R_CreateImage( const char *name, const char *name2, byte *pic, int widt
 	image->colorSpace = R_ImageColorSpaceForFlags( image->imgName, image->flags );
 
 	if ( namelen > 6 && Q_stristr( image->imgName, "maps/" ) == image->imgName && Q_stristr( image->imgName + 6, "/lm_" ) != NULL ) {
-		// external lightmap atlases stored in maps/<mapname>/lm_XXXX textures
-		// image->flags = IMGFLAG_NOLIGHTSCALE | IMGFLAG_NO_COMPRESSION | IMGFLAG_NOSCALE | IMGFLAG_COLORSHIFT;
-		image->flags |= IMGFLAG_NO_COMPRESSION | IMGFLAG_NOSCALE | IMGFLAG_COLORSPACE_LINEAR;
+		// external lightmap atlases stored in maps/<mapname>/lm_XXXX textures.
+		// These arrive through the regular shader/image path, so they must be
+		// forced onto the same contract R_LoadLightmaps() gives BSP lightmaps:
+		// bake the overbright/greyscale shift (R_ProcessLightmap() does that for
+		// the internal ones), skip the intensity+gamma light scale so it is not
+		// applied on top of the diffuse texture's, and keep the authored size.
+		// picmip and mipmapping are cleared because a packed atlas has no border
+		// padding, so they would blur and bleed neighbouring lightmap tiles.
+		image->flags &= ~( IMGFLAG_MIPMAP | IMGFLAG_PICMIP );
+		image->flags |= IMGFLAG_NOLIGHTSCALE | IMGFLAG_NO_COMPRESSION | IMGFLAG_NOSCALE |
+			IMGFLAG_COLORSHIFT | IMGFLAG_COLORSPACE_LINEAR;
 		image->colorSpace = IMAGE_COLORSPACE_LINEAR;
 	}
 	image->srgbDecode = R_ImageWantsSrgbDecode( image->colorSpace );

--- a/code/renderervk/tr_image.c
+++ b/code/renderervk/tr_image.c
@@ -1065,9 +1065,17 @@ image_t *R_CreateImage( const char *name, const char *name2, byte *pic, int widt
 	image->colorSpace = R_ImageColorSpaceForFlags( image->imgName, image->flags );
 
 	if ( namelen > 6 && Q_stristr( image->imgName, "maps/" ) == image->imgName && Q_stristr( image->imgName + 6, "/lm_" ) != NULL ) {
-		// external lightmap atlases stored in maps/<mapname>/lm_XXXX textures
-		// image->flags = IMGFLAG_NOLIGHTSCALE | IMGFLAG_NO_COMPRESSION | IMGFLAG_NOSCALE | IMGFLAG_COLORSHIFT;
-		image->flags |= IMGFLAG_NO_COMPRESSION | IMGFLAG_NOSCALE | IMGFLAG_COLORSPACE_LINEAR;
+		// external lightmap atlases stored in maps/<mapname>/lm_XXXX textures.
+		// These arrive through the regular shader/image path, so they must be
+		// forced onto the same contract R_LoadLightmaps() gives BSP lightmaps:
+		// bake the overbright/greyscale shift (R_ProcessLightmap() does that for
+		// the internal ones), skip the intensity+gamma light scale so it is not
+		// applied on top of the diffuse texture's, and keep the authored size.
+		// picmip and mipmapping are cleared because a packed atlas has no border
+		// padding, so they would blur and bleed neighbouring lightmap tiles.
+		image->flags &= ~( IMGFLAG_MIPMAP | IMGFLAG_PICMIP );
+		image->flags |= IMGFLAG_NOLIGHTSCALE | IMGFLAG_NO_COMPRESSION | IMGFLAG_NOSCALE |
+			IMGFLAG_COLORSHIFT | IMGFLAG_COLORSPACE_LINEAR;
 		image->colorSpace = IMAGE_COLORSPACE_LINEAR;
 	}
 	image->srgbDecode = R_ImageWantsSrgbDecode( image->colorSpace );

--- a/docs/fnql/CHANGELOG.md
+++ b/docs/fnql/CHANGELOG.md
@@ -37,6 +37,10 @@ release, CI resets `Unreleased` for the next cycle.
 ### Fixes
 - Keep the mouse cursor usable in the in-game menu, scoreboard, and other
   cgame/UI overlays while supersampling is enabled.
+- Light maps that ship external lightmap atlases (`maps/<mapname>/lm_*`) the same
+  way as maps with lightmaps stored inside the BSP. They previously ignored
+  `r_mapOverBrightBits`, `r_mapOverBrightCap`, and `r_mapGreyScale`, took
+  `r_intensity` and gamma a second time, and were blurred by `r_picmip`.
 
 ### Documentation and Tooling
 - _None yet._


### PR DESCRIPTION
## What

External lightmap atlases (`maps/<mapname>/lm_XXXX`) are now put on the same
contract that `R_LoadLightmaps()` gives lightmaps stored inside the BSP.
Applied identically to the OpenGL-lineage, Vulkan, and RTX renderers.

## Why

These atlases never pass through `R_LoadLightmaps()` — they arrive via the
regular shader/image path and are recognised only by a name sniff in
`R_CreateImage()`. That hook set `IMGFLAG_NO_COMPRESSION | IMGFLAG_NOSCALE |
IMGFLAG_COLORSPACE_LINEAR`, which left four gaps against `lightmapFlags`
(`tr_bsp.c`):

1. **No overbright shift.** Internal lightmaps run through `R_ProcessLightmap()`
   -> `R_ColorShiftLightingBytes()`, applying `r_mapOverBrightBits -
   tr.overbrightBits`, the `r_mapOverBrightCap` normalisation, and
   `r_mapGreyScale`. External ones got none of it. With stock settings
   (`r_mapOverBrightBits 2`, `tr.overbrightBits` forced to 0 without hardware
   gamma) internal lightmaps come out up to 4x brighter — same map, different
   lighting depending only on where the lightmap is stored.
2. **`IMGFLAG_COLORSHIFT` was dead engine-wide.** All three renderers implement
   the consumer in their upload paths; nothing ever set the flag. The only other
   mentions were commented-out lines directly above this hook.
3. **Light scale applied twice.** Without `IMGFLAG_NOLIGHTSCALE`,
   `R_LightScaleTexture()` ran on external lightmaps, so `r_intensity` (and
   gamma, absent hardware gamma/FBO) hit them once in the lightmap and again in
   the diffuse texture they multiply against. Internal lightmaps skip it.
4. **`|=` let `MIPMAP` and `PICMIP` survive.** Shader stages set both.
   `IMGFLAG_NOSCALE` does not help here — it only skips the power-of-two
   rounding, and the picmip block below runs regardless. `r_picmip 3` shrank a
   lightmap atlas 8x, and mipmapping bled adjacent tiles together. Internal
   merged atlases are protected by a 2px border plus `GL_CLAMP_TO_BORDER`; a
   packed `lm_` atlas has no such padding.

## Reviewer notes

- The upstream Quake3e line (preserved as a comment in the pre-change source)
  achieved this with a blunt `=` that also clobbered flags the caller had set.
  This uses an explicit `&= ~(MIPMAP|PICMIP)` plus `|=` instead, so clamp mode
  and other caller flags are untouched. Clamp mode and `IMGFLAG_RGB` are read
  from the local `flags` parameter rather than `image->flags`, so they were
  never affected either way.
- `IMGFLAG_LIGHTMAP` is deliberately **not** set. It would only be half-applied:
  the GL renderer reads it from the local `flags` for TMU-1 placement, not from
  `image->flags`, so setting it here would change the internal-format choice
  without changing TMU assignment.
- **Out of scope:** maps built with q3map2 `-external` still render fullbright.
  That scheme leaves `LUMP_LIGHTMAPS` empty and keeps `lightmapNum >= 0` on
  surfaces, expecting the engine to load `maps/<mapname>/lm_XXXX.tga` itself.
  `R_LoadLightmaps()` never does, so `tr.lightmaps` stays NULL and `$lightmap`
  stages fall back to `tr.whiteImage`. It degrades safely — no crash — but the
  map is unlit. Adding that loader is a feature, not a correctness fix; happy to
  do it separately if FnQL should run stock Quake Live maps, which use that
  layout.
- Pre-existing wart left alone: mutating `image->flags` after the caller computed
  `flags` makes every later `R_FindImageFile()` on the same `lm_` texture trip
  the mixed-flags warning. `PRINT_DEVELOPER` only, inherited from upstream.

## Testing

- `tests/untrusted_asset_bounds_tests.py` and `tests/ql_font_source_tests.py`:
  59 passed, 29 subtests passed.
- All three modified translation units syntax-check clean under MSVC (`cl /Zs`).
- Not exercised on a live GPU against a map with external lightmap atlases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
